### PR TITLE
Quiz Preview - Markdown render

### DIFF
--- a/app/pods/components/question-preview/template.hbs
+++ b/app/pods/components/question-preview/template.hbs
@@ -1,21 +1,42 @@
 <div>
-    <h3>Question - {{question.title}}</h3>
-    <p><b>Description -</b> {{question.description}}</p>
+    <h3>
+        <div class="row justify-content-center align-items-center m-0 p-0">
+            <div class="col-4">
+                Question -
+            </div>
+            <div class="col">
+                {{markdown-to-html question.title}}
+            </div>
+        </div>
+
+    </h3>
+    <p><b>Description -</b> {{markdown-to-html question.description}}</p>
     <br>
+
     {{#each question.choices as |choice|}}
-        {{#if question.multicorrect}}
-            {{input type="checkbox" checked=(mark-option question.id choice.id answers) name="questionChoices"
-                    click=(action "selectChoiceAndMark" question.id choice.id)}}
-            {{choice.title}}
-            <br>
-        {{else}}
-            {{#radio-button value=choice.id groupValue=selectedChoice name="questionChoices"
-                            changed=(action "selectChoiceAndMark" question.id choice.id)}}
-                {{choice.title}}
-            {{/radio-button}}
-            <br>
-        {{/if}}
-        {{choice.description}}<br><br>
+        <div class="row justify-content-center align-items-center m-0 p-0">
+            {{#if question.multicorrect}}
+                <div class="col-1 input-group">
+                    {{input type="checkbox" checked=(mark-option question.id choice.id answers)
+                            name="questionChoices" click=(action "selectChoiceAndMark" question.id choice.id)}}
+                </div>
+                <div class="col">
+                    {{markdown-to-html choice.title extensions='katex'}}
+                </div>
+            {{else}}
+                <div class="col-1 input-group">
+                    {{#radio-button value=choice.id groupValue=selectedChoice name="questionChoices"
+                                    changed=(action "selectChoiceAndMark" question.id choice.id)}}
+                    {{/radio-button}}
+                </div>
+                <div class="col">
+                    {{markdown-to-html choice.title extensions='katex'}}
+                </div>
+            {{/if}}
+        </div>
+        <div class="row align-items-center m-0 p-0">
+            {{markdown-to-html choice.description}}
+        </div>
     {{/each}}
     <br><br>
 </div>


### PR DESCRIPTION
Quiz preview option does not currently render the markdown in the question title,description & choices. This creates problem as the problem setter cannot actually "preview" the quiz at all if any markdown is involved.

<br>
Below is a screenshot of one of the problems at the current troublemaker.
![Screenshot from 2020-09-05 14-10-05](https://user-images.githubusercontent.com/43583175/92301491-e9c45800-ef81-11ea-8e59-603584985d21.png)

<br>

As it can be clearly seen, the code inside  Question Description is not rendered.
I have updated the question-preview template so that this markdown content can be rendered. Below is a screenshot of the same problem with the changes.
![Screenshot from 2020-09-05 14-10-08](https://user-images.githubusercontent.com/43583175/92301520-27c17c00-ef82-11ea-901f-e30a51a9f7da.png)


Kindly review it.
@jatinkatyal13 